### PR TITLE
Fixes issue where form params weren't being forwarded

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring-request-proxy "0.1.3"
+(defproject ring-request-proxy "0.1.4"
   :description "Ring request proxy"
   :url "https://github.com/FundingCircle/ring-request-proxy"
   :license {:name "BSD 3-clause"

--- a/spec/ring_request_proxy/core_spec.clj
+++ b/spec/ring_request_proxy/core_spec.clj
@@ -5,68 +5,84 @@
 
 (def hello-request
   {"hello.com/gatekeeper" {:get (fn [req]
-                                  {:status 200
+                                  {:status  200
                                    :headers {:content-type "application/json"}
-                                   :body "{}"})}})
+                                   :body    "{}"})}})
 
 (def post-request
   {"hello.com/postit" {:post (fn [req]
-                               (if (get-in req [:headers "content-length"])
-                                 (throw (Exception. "content-length header already present"))
-                                 {:status 201 :body (slurp (:body req))}))}})
+                               (cond
+                                 (not (nil? (get-in req [:headers "content-length"]))) (throw (Exception. "content-length header already present"))
+                                 (nil? (:body req)) (throw (Exception. "should have a body"))
+                                 :else {:status 201 :body (slurp (:body req))}))}})
 
 (context "ring-request-proxy.core"
   (describe "proxy-request"
     (context "when forwarding server is not found"
       (with proxy-with-handler-fn (proxy-request (constantly {:status 200})
                                                  {:identifier-fn :server-name
-                                                  :host-fn {}}))
+                                                  :host-fn       {}}))
       (with proxy-fn (proxy-request {:identifier-fn :server-name
-                                     :host-fn {}}))
+                                     :host-fn       {}}))
 
       (it "is not found when no optional handler supplied"
-        (should= 404
-                 (:status (@proxy-fn {:server-name "here" :request-method :get}))))
+          (should= 404
+                   (:status (@proxy-fn {:server-name "here" :request-method :get}))))
 
       (it "responds with the optional handler when present"
-        (should= 200
-                 (:status (@proxy-with-handler-fn {:server-name "here" :request-method :get})))))
+          (should= 200
+                   (:status (@proxy-with-handler-fn {:server-name "here" :request-method :get})))))
 
     (context "when forwarding server is found"
       (with proxy-fn (proxy-request {:identifier-fn :server-name
-                                     :host-fn {"hello" "http://hello.com"}}))
+                                     :host-fn       {"hello" "http://hello.com"}}))
       (with response
         (with-fake-routes-in-isolation hello-request
-          (@proxy-fn {:server-name "hello"
-                      :request-method :get
-                      :uri "/gatekeeper"})))
+                                       (@proxy-fn {:server-name    "hello"
+                                                   :request-method :get
+                                                   :uri            "/gatekeeper"})))
       (it "forwards the response status"
-        (should= 200
-                 (:status @response)))
+          (should= 200
+                   (:status @response)))
 
       (it "forwards the response body as an input stream"
-        (should= "{}"
-                 (slurp (:body @response))))
+          (should= "{}"
+                   (slurp (:body @response))))
 
       (it "forwards the response header"
-        (should= {:content-type "application/json"}
-                (:headers @response))))
+          (should= {:content-type "application/json"}
+                   (:headers @response))))
 
-    (context "when forwarding server is found"
+    (context "POST request"
       (with proxy-fn (proxy-request (fn [handler]
                                       (fn [request]
                                         (handler request))) {:identifier-fn :server-name
-                                     :host-fn       {"hello" "http://hello.com"}}))
+                                                             :host-fn       {"hello" "http://hello.com"}}))
       (with response
-            (with-fake-routes-in-isolation post-request
-                                           (@proxy-fn {:server-name    "hello"
-                                                       :request-method :post
-                                                       :uri            "/postit"
-                                                       :headers {"content-length" (count "some post body")}
-                                                       :body "some post body"})))
+        (with-fake-routes-in-isolation post-request
+                                       (@proxy-fn {:server-name    "hello"
+                                                   :request-method :post
+                                                   :uri            "/postit"
+                                                   :headers        {"content-length" (count "some post body")}
+                                                   :body           "some post body"})))
       (it "does not throw content-length already present exception"
         (let [_ @response]
-          (should-not-throw (Exception.)))))))
+          (should-not-throw (Exception.)))))
+
+    (context "with form-params"
+      (with proxy-fn (proxy-request (fn [handler]
+                                      (fn [request]
+                                        (handler request))) {:identifier-fn :server-name
+                                                             :host-fn       {"hello" "http://hello.com"}}))
+      (with response
+        (with-fake-routes-in-isolation post-request
+                                       (@proxy-fn {:server-name    "hello"
+                                                   :request-method :post
+                                                   :uri            "/postit"
+                                                   :form-params    {:foo "bar"}})))
+      (it "forwards the form-parms"
+          (let [_ @response]
+            (should-not-throw (Exception.)))))))
 
 
 (run-specs)

--- a/src/ring_request_proxy/core.clj
+++ b/src/ring_request_proxy/core.clj
@@ -24,6 +24,7 @@
                                         :body             (:body request)
                                         :headers          stripped-headers
                                         :query-params     (:query-params request)
+                                        :form-params      (:form-params request)
                                         :throw-exceptions false
                                         :as               :stream})
                        [:status :headers :body])


### PR DESCRIPTION
The problem was that a previous middleware could read `(:body request)`, which is a BytesInputStream.  By the time the execution reached ring-request-proxy, you'd be at the end of the stream, so the forwarded request body would be empty.

@aprobus - This bumps ring-request-proxy to 0.1.4, and can you please deploy to clojars?  Thank you. 