### PR TITLE
No longer assumes the presence of (:query-params request)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring-request-proxy "0.1.3"
+(defproject ring-request-proxy "0.1.4"
   :description "Ring request proxy"
   :url "https://github.com/FundingCircle/ring-request-proxy"
   :license {:name "BSD 3-clause"

--- a/src/ring_request_proxy/core.clj
+++ b/src/ring_request_proxy/core.clj
@@ -5,8 +5,11 @@
 (def ^:private not-found-response {:status 404
                                    :body (json/write-str {:message "Not found"})})
 
-(defn- build-url [host path]
-  (.toString (java.net.URL. (java.net.URL. host) path)))
+(defn- build-url [host path query-string]
+  (let [url (.toString (java.net.URL. (java.net.URL. host) path))]
+    (if (not-empty query-string)
+      (str url "?" query-string)
+      url)))
 
 (defn- handle-not-found [request]
   not-found-response)
@@ -19,11 +22,10 @@
             host (server-mapping request-key)
             stripped-headers (dissoc (:headers request) "content-length")]
         (if host
-          (select-keys (client/request {:url              (build-url host (:uri request))
+          (select-keys (client/request {:url              (build-url host (:uri request) (:query-string request))
                                         :method           (:request-method request)
                                         :body             (:body request)
                                         :headers          stripped-headers
-                                        :query-params     (:query-params request)
                                         :throw-exceptions false
                                         :as               :stream})
                        [:status :headers :body])


### PR DESCRIPTION
Previously, we were assuming that `wrap-params` had been called.  We no longer make that assumption.

Bumps version to 0.1.4 - @aprobus can you please deploy to clojars?  Thank you.

@FundingCircle/investor-track 