### PR TITLE
Adding a way to allow insecure https connections.

### DIFF
--- a/src/ring_request_proxy/core.clj
+++ b/src/ring_request_proxy/core.clj
@@ -16,7 +16,8 @@
 
 (defn- create-proxy-fn [handler opts]
   (let [identifier-fn (get opts :identifier-fn identity)
-        server-mapping (get opts :host-fn {})]
+        server-mapping (get opts :host-fn {})
+        insecure (get opts :allow-insecure-ssl false)]
     (fn [request]
       (let [request-key (identifier-fn request)
             host (server-mapping request-key)
@@ -27,7 +28,8 @@
                                         :body             (:body request)
                                         :headers          stripped-headers
                                         :throw-exceptions false
-                                        :as               :stream})
+                                        :as               :stream
+                                        :insecure?        insecure})
                        [:status :headers :body])
           (handler request))))))
 


### PR DESCRIPTION
I was using this to test http-kit, and I noticed that when sending things to self-signed certs I needed a way to flip the `insecure?` option.

If you could give me a rough idea of how you'd like this tested I'll add it in.
