### PR TITLE
Replace Host header with the passed in value

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Clojure library for proxying requests in ring applications.
 
+[![CircleCI](https://circleci.com/gh/FundingCircle/ring-request-proxy.svg?style=svg)](https://circleci.com/gh/FundingCircle/ring-request-proxy)
+
 ## Installation
 
 [![Clojars Project](https://img.shields.io/clojars/v/ring-request-proxy.svg)](https://clojars.org/ring-request-proxy)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Clojure library for proxying requests in ring applications.
 
 ## Installation
 
-[ring-request-proxy "0.1.3"]
+[![Clojars Project](https://img.shields.io/clojars/v/ring-request-proxy.svg)](https://clojars.org/ring-request-proxy)
 
 ## Usage
 


### PR DESCRIPTION
Allows customisation of `Host: ` headers to occur.