### PR TITLE
Deploy artefacts to Clojars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,9 @@ jobs:
           key: ring-request-proxy-{{ checksum "project.clj" }}
           paths:
             - ~/.m2
-      - run: lein spec
+      - run: lein spec -f junit -f progress
+      - store_test_results:
+          path: target
       - deploy:
           name: Release version to Clojars, tag and bump snapshot version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,4 +13,7 @@ jobs:
           paths:
             - ~/.m2
       - run: lein spec
+      - deploy:
+          name: Deploy to Clojars
+          command: lein deploy clojars
     working_directory: ~/ring-request-proxy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: clojure:lein
+    steps:
+      - checkout
+      - restore_cache:
+          key: ring-request-proxy-{{ checksum "project.clj" }}
+      - run: lein deps
+      - save_cache:
+          key: ring-request-proxy-{{ checksum "project.clj" }}
+          paths:
+            - ~/.m2
+      - run: lein spec
+    working_directory: ~/ring-request-proxy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,11 @@ jobs:
             - ~/.m2
       - run: lein spec
       - deploy:
-          name: Deploy to Clojars
-          command: lein deploy clojars
+          name: Release version to Clojars, tag and bump snapshot version
+          command: |
+            if [ "$CIRCLE_BRANCH" == "master" ]; then
+              git config user.email noreply+ring-request-proxy@fundingcircle.com
+              git config user.name "CircleCI"
+              lein release
+            fi
     working_directory: ~/ring-request-proxy

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-test:
-  override:
-    - lein spec

--- a/project.clj
+++ b/project.clj
@@ -9,4 +9,12 @@
   :test-paths ["spec"]
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [clj-http "1.1.2"]
-                 [org.clojure/data.json "0.2.6"]])
+                 [org.clojure/data.json "0.2.6"]]
+  :repositories [["snapshots" {:sign-releases false
+                               :url           "https://clojars.org/repo"
+                               :username      [:gpg :env]
+                               :password      [:gpg :env]}]
+                 ["releases"  {:sign-releases false
+                               :url           "https://clojars.org/repo"
+                               :username      [:gpg :env]
+                               :password      [:gpg :env]}]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring-request-proxy "0.1.4"
+(defproject ring-request-proxy "0.1.4-SNAPSHOT"
   :description "Ring request proxy"
   :url "https://github.com/FundingCircle/ring-request-proxy"
   :license {:name "BSD 3-clause"

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "http://opensource.org/licenses/BSD-3-Clause"}
   :plugins [[speclj "3.2.0"]]
   :profiles {:dev {:dependencies [[speclj "3.2.0"]
+                                  [speclj-junit "0.0.11"]
                                   [clj-http-fake "1.0.1"]]}}
   :test-paths ["spec"]
   :dependencies [[org.clojure/clojure "1.6.0"]


### PR DESCRIPTION
💁 These changes delegate control of the project version and releasing versions to [Clojars](https://clojars.org) over to `lein release`. I think the tasks which run as part of `lein release` are sensible defaults and we should use them.

An added bonus is speeding up the continuous integration build.