### PR TITLE
Tag commits without attempting GPG signing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,14 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [clj-http "1.1.2"]
                  [org.clojure/data.json "0.2.6"]]
+  :release-tasks [["vcs" "assert-committed"]
+                  ["change" "version" "leiningen.release/bump-version" "release"]
+                  ["vcs" "commit"]
+                  ["vcs" "tag" "--no-sign"]
+                  ["deploy"]
+                  ["change" "version" "leiningen.release/bump-version"]
+                  ["vcs" "commit"]
+                  ["vcs" "push"]]
   :repositories [["snapshots" {:sign-releases false
                                :url           "https://clojars.org/repo"
                                :username      [:gpg :env]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring-request-proxy "0.1.4-SNAPSHOT"
+(defproject ring-request-proxy "0.1.6-SNAPSHOT"
   :description "Ring request proxy"
   :url "https://github.com/FundingCircle/ring-request-proxy"
   :license {:name "BSD 3-clause"


### PR DESCRIPTION
💁 After changing the deployment stage of the build to use `lein release`, the [build exploded when attempting to GPG sign the git tag](https://circleci.com/gh/FundingCircle/ring-request-proxy/36). I've dug around in [leiningen's `vcs` code](https://github.com/technomancy/leiningen/blob/master/src/leiningen/vcs.clj) to find a way to override the default tag signing behaviour. It appears that there's no way to control this without explicitly redefining the `:release-tasks` and passing `--no-sign` to `vcs tag`. 😞 