### PR TITLE
Don't automatically decompress bodies when proxying

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,13 +3,13 @@
   :url "https://github.com/FundingCircle/ring-request-proxy"
   :license {:name "BSD 3-clause"
             :url "http://opensource.org/licenses/BSD-3-Clause"}
-  :plugins [[speclj "3.2.0"]]
-  :profiles {:dev {:dependencies [[speclj "3.2.0"]
+  :plugins [[speclj "3.3.2"]]
+  :profiles {:dev {:dependencies [[speclj "3.3.2"]
                                   [speclj-junit "0.0.11"]
-                                  [clj-http-fake "1.0.1"]]}}
+                                  [clj-http-fake "1.0.3"]]}}
   :test-paths ["spec"]
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clj-http "1.1.2"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [clj-http "3.7.0"]
                  [org.clojure/data.json "0.2.6"]]
   :release-tasks [["vcs" "assert-committed"]
                   ["vcs" "tag" "--no-sign"]

--- a/src/ring_request_proxy/core.clj
+++ b/src/ring_request_proxy/core.clj
@@ -27,11 +27,12 @@
             stripped-headers (dissoc (:headers request) "content-length")
             replaced-host-headers (assoc stripped-headers "host" (host-from-url host))]
         (if host
-          (select-keys (client/request {:url              (build-url host (:uri request) (:query-string request)) 
+          (select-keys (client/request {:url              (build-url host (:uri request) (:query-string request))
                                         :method           (:request-method request)
                                         :body             (:body request)
                                         :headers          replaced-host-headers
                                         :throw-exceptions false
+                                        :decompress-body  false
                                         :as               :stream})
                        [:status :headers :body])
           (handler request))))))


### PR DESCRIPTION
@aprobus and I discovered clj-http automatically decompresses GZIPed response bodies. This probably isn't the desired effect, so we propose disabled decompression.