### PR TITLE
Downgrade clj-http to avoiding breaking changes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring-request-proxy "0.1.10"
+(defproject ring-request-proxy "0.1.11"
   :description "Ring request proxy"
   :url "https://github.com/FundingCircle/ring-request-proxy"
   :license {:name "BSD 3-clause"
@@ -9,7 +9,7 @@
                                   [clj-http-fake "1.0.3"]]}}
   :test-paths ["spec"]
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [clj-http "3.7.0"]
+                 [clj-http "2.0.0"]
                  [org.clojure/data.json "0.2.6"]]
   :release-tasks [["vcs" "assert-committed"]
                   ["vcs" "tag" "--no-sign"]


### PR DESCRIPTION
We discovered that something about the 2.0 -> 3.7 transition of clj-http introduces changes that somehow break GZIP streaming. Downgrading to maintain existing behavior.